### PR TITLE
Correct Jared Norman's blog URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@
 * [Jamie Schembri](https://schembri.me/post/)
 * [Janko Marohnić](https://janko.io/)
 * [Jan Matuszewski](https://jmatuszewski.com/)
-* [Jared Norman](https://www.jardo.dev/ruby-rails)
+* [Jared Norman](https://jardo.dev/ruby-rails)
 * [Jason Charnes](https://jasoncharnes.com/articles/)
 * [Jason Swett](https://www.codewithjason.com/articles/)
 * [Jason York](https://predicatemethod.com/archives/)


### PR DESCRIPTION
I've just tweaked things to make the `www` redirect like it used to, but the correct URL is the one with no `www`.