### PR TITLE
Add DotRuby articles to the company list

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@
 * [Cookpad](https://sourcediving.com/tagged/ruby)
 * [Datarockets](https://datarockets.com/blog/)
 * [DeepSource](https://deepsource.com/blog-category/ruby)
+* [DotRuby](https://www.dotruby.com/articles)
 * [Doximity](https://technology.doximity.com/sitemaps)
 * [Engine Yard](https://www.engineyard.com/blog/tag/ruby-on-rails/)
 * [Evil Martians](https://evilmartians.com/chronicles)


### PR DESCRIPTION
Added our company blog (mainly about Ruby, Rails, Hotwire etc.) to the list. Thanks a lot for your useful repo! 👏 