### PR TITLE
Add Bhumi's blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@
 * [Benoit Daloze](https://eregon.me/blog/) ([rss](https://eregon.me/blog/feed.xml))
 * [Benoit Tigeot](https://benoittgt.github.io/blog/) ([rss](https://benoittgt.github.io/feed/feed.xml))
 * [Bernie Chiu](https://berniechiu.github.io/blog/) ([rss](https://berniechiu.github.io/blog/sitemap.xml))
+* [Bhumi](https://theleafnode.com/) ([rss](https://theleafnode.com/feed.xml))
 * [Bill Tihen](https://btihen.dev/posts/ruby/) ([rss](https://btihen.dev/posts/ruby/index.xml))
 * [Bohdan Pohorilets](https://bpohoriletz.github.io/) ([rss](https://bpohoriletz.github.io/feed.xml))
 * [Borja Garcia de Vinuesa Ordovás](https://bgvo.io/) ([rss](https://bgvo.io/feed.xml))

--- a/data/personal.yml
+++ b/data/personal.yml
@@ -141,6 +141,9 @@
 - name: Bernie Chiu
   url: https://berniechiu.github.io/blog/
   rss: https://berniechiu.github.io/blog/sitemap.xml
+- name: Bhumi
+  url: https://theleafnode.com/
+  rss: https://theleafnode.com/feed.xml
 - name: Bill Tihen
   url: https://btihen.dev/posts/ruby/
   rss: https://btihen.dev/posts/ruby/index.xml

--- a/opml/all.opml
+++ b/opml/all.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Mon, 08 Sep 2025 11:07:06 +0300</dateModified>
+    <dateModified>Mon, 08 Sep 2025 09:38:45 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: community'>
@@ -182,6 +182,7 @@
       <outline type='rss' text='Benoit Tigeot' xmlUrl='https://benoittgt.github.io/feed/feed.xml'/>
       <outline type='rss' text='Ben Sheldon' xmlUrl='https://island94.org/feed.xml'/>
       <outline type='rss' text='Bernie Chiu' xmlUrl='https://berniechiu.github.io/blog/sitemap.xml'/>
+      <outline type='rss' text='Bhumi' xmlUrl='https://theleafnode.com/feed.xml'/>
       <outline type='rss' text='Bill Tihen' xmlUrl='https://btihen.dev/posts/ruby/index.xml'/>
       <outline type='rss' text='Bohdan Pohorilets' xmlUrl='https://bpohoriletz.github.io/feed.xml'/>
       <outline type='rss' text='Borja Garcia de Vinuesa Ordovás' xmlUrl='https://bgvo.io/feed.xml'/>

--- a/opml/community.opml
+++ b/opml/community.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Mon, 08 Sep 2025 11:07:06 +0300</dateModified>
+    <dateModified>Mon, 08 Sep 2025 09:38:45 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: community'>

--- a/opml/company.opml
+++ b/opml/company.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Mon, 08 Sep 2025 11:07:06 +0300</dateModified>
+    <dateModified>Mon, 08 Sep 2025 09:38:45 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: company'>

--- a/opml/newsletter.opml
+++ b/opml/newsletter.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Mon, 08 Sep 2025 11:07:06 +0300</dateModified>
+    <dateModified>Mon, 08 Sep 2025 09:38:45 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: newsletter'>

--- a/opml/other.opml
+++ b/opml/other.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Mon, 08 Sep 2025 11:07:06 +0300</dateModified>
+    <dateModified>Mon, 08 Sep 2025 09:38:45 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: other'/>

--- a/opml/personal.opml
+++ b/opml/personal.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Mon, 08 Sep 2025 11:07:06 +0300</dateModified>
+    <dateModified>Mon, 08 Sep 2025 09:38:45 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: personal'>
@@ -47,6 +47,7 @@
       <outline type='rss' text='Benoit Tigeot' xmlUrl='https://benoittgt.github.io/feed/feed.xml'/>
       <outline type='rss' text='Ben Sheldon' xmlUrl='https://island94.org/feed.xml'/>
       <outline type='rss' text='Bernie Chiu' xmlUrl='https://berniechiu.github.io/blog/sitemap.xml'/>
+      <outline type='rss' text='Bhumi' xmlUrl='https://theleafnode.com/feed.xml'/>
       <outline type='rss' text='Bill Tihen' xmlUrl='https://btihen.dev/posts/ruby/index.xml'/>
       <outline type='rss' text='Bohdan Pohorilets' xmlUrl='https://bpohoriletz.github.io/feed.xml'/>
       <outline type='rss' text='Borja Garcia de Vinuesa Ordovás' xmlUrl='https://bgvo.io/feed.xml'/>

--- a/opml/social_news_aggregation.opml
+++ b/opml/social_news_aggregation.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Mon, 08 Sep 2025 11:07:06 +0300</dateModified>
+    <dateModified>Mon, 08 Sep 2025 09:38:45 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: social_news_aggregation'>


### PR DESCRIPTION
Adds a personal blog by Bhumi: <https://theleafnode.com>

The same content is also in Bhumi's newsletter "One Ruby Question" (<https://buttondown.com/bhumi>) but I added the blog instead because the newsletter doesn't include an archive of past posts, or an RSS feed. (The newsletter is linked from the blog, so it's easily discoverable there.)