### PR TITLE
Add several podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,10 +637,17 @@
 
 ## Podcast [![OPML](https://img.shields.io/badge/OPML-000000?style=flat-square&color=orange)](/opml/podcast.opml)
 
+* [Code and the Coding Coders who Code it](https://podcast.drbragg.dev) ([rss](https://feeds.buzzsprout.com/1927628.rss))
+* [Code with Jason](https://www.codewithjason.com/podcast) ([rss](https://feeds.buzzsprout.com/1878319.rss))
 * [Dead Code](https://shows.acast.com/dead-code) ([rss](https://feeds.acast.com/public/shows/dead-code))
+* [Friendly Show](https://www.friendly.show) ([rss](https://feeds.buzzsprout.com/2278525.rss))
+* [IndieRails](https://www.indierails.com) ([rss](https://feeds.transistor.fm/indierails))
+* [On Rails](https://onrails.buzzsprout.com) ([rss](https://feeds.buzzsprout.com/2462975.rss))
 * [Remote Ruby](https://www.remoteruby.com/) ([rss](https://feeds.buzzsprout.com/2260490.rss))
 * [Rooftop Ruby Podcast](https://www.rooftopruby.com/) ([rss](https://feeds.buzzsprout.com/2108545.rss))
 * [Ruby Rogues](https://topenddevs.com/podcasts/ruby-rogues/) ([rss](https://www.spreaker.com/show/6102073/episodes/feed))
+* [The Bike Shed](https://bikeshed.thoughtbot.com) ([rss](https://feeds.fireside.fm/bikeshed/rss))
+* [The Ruby Gems Podcast](https://www.buzzsprout.com/2509083) ([rss](https://feeds.buzzsprout.com/2509083.rss))
 * [The Ruby on Rails Podcast](https://www.therubyonrailspodcast.com/) ([rss](https://www.therubyonrailspodcast.com/rss))
 
 

--- a/data/podcast.yml
+++ b/data/podcast.yml
@@ -1,7 +1,22 @@
 ---
+- name: Code and the Coding Coders who Code it
+  url: https://podcast.drbragg.dev
+  rss: https://feeds.buzzsprout.com/1927628.rss
+- name: Code with Jason
+  url: https://www.codewithjason.com/podcast
+  rss: https://feeds.buzzsprout.com/1878319.rss
 - name: Dead Code
   url: https://shows.acast.com/dead-code
   rss: https://feeds.acast.com/public/shows/dead-code
+- name: Friendly Show
+  url: https://www.friendly.show
+  rss: https://feeds.buzzsprout.com/2278525.rss
+- name: IndieRails
+  url: https://www.indierails.com
+  rss: https://feeds.transistor.fm/indierails
+- name: On Rails
+  url: https://onrails.buzzsprout.com
+  rss: https://feeds.buzzsprout.com/2462975.rss
 - name: Remote Ruby
   url: https://www.remoteruby.com/
   rss: https://feeds.buzzsprout.com/2260490.rss
@@ -11,6 +26,12 @@
 - name: Ruby Rogues
   url: https://topenddevs.com/podcasts/ruby-rogues/
   rss: https://www.spreaker.com/show/6102073/episodes/feed
+- name: The Bike Shed
+  url: https://bikeshed.thoughtbot.com
+  rss: https://feeds.fireside.fm/bikeshed/rss
+- name: The Ruby Gems Podcast
+  url: https://www.buzzsprout.com/2509083
+  rss: https://feeds.buzzsprout.com/2509083.rss
 - name: The Ruby on Rails Podcast
   url: https://www.therubyonrailspodcast.com/
   rss: https://www.therubyonrailspodcast.com/rss

--- a/opml/all.opml
+++ b/opml/all.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Sat, 04 Oct 2025 19:43:42 +0300</dateModified>
+    <dateModified>Mon, 06 Oct 2025 09:48:55 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: community'>
@@ -435,10 +435,17 @@
       <outline type='rss' text='Владимир Мирошниченко' xmlUrl='https://gururuby.ru/atom.xml'/>
     </outline>
     <outline text='Awesome Ruby Blogs: podcast'>
+      <outline type='rss' text='Code and the Coding Coders who Code it' xmlUrl='https://feeds.buzzsprout.com/1927628.rss'/>
+      <outline type='rss' text='Code with Jason' xmlUrl='https://feeds.buzzsprout.com/1878319.rss'/>
       <outline type='rss' text='Dead Code' xmlUrl='https://feeds.acast.com/public/shows/dead-code'/>
+      <outline type='rss' text='Friendly Show' xmlUrl='https://feeds.buzzsprout.com/2278525.rss'/>
+      <outline type='rss' text='IndieRails' xmlUrl='https://feeds.transistor.fm/indierails'/>
+      <outline type='rss' text='On Rails' xmlUrl='https://feeds.buzzsprout.com/2462975.rss'/>
       <outline type='rss' text='Remote Ruby' xmlUrl='https://feeds.buzzsprout.com/2260490.rss'/>
       <outline type='rss' text='Rooftop Ruby Podcast' xmlUrl='https://feeds.buzzsprout.com/2108545.rss'/>
       <outline type='rss' text='Ruby Rogues' xmlUrl='https://www.spreaker.com/show/6102073/episodes/feed'/>
+      <outline type='rss' text='The Bike Shed' xmlUrl='https://feeds.fireside.fm/bikeshed/rss'/>
+      <outline type='rss' text='The Ruby Gems Podcast' xmlUrl='https://feeds.buzzsprout.com/2509083.rss'/>
       <outline type='rss' text='The Ruby on Rails Podcast' xmlUrl='https://www.therubyonrailspodcast.com/rss'/>
     </outline>
     <outline text='Awesome Ruby Blogs: social_news_aggregation'>

--- a/opml/community.opml
+++ b/opml/community.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Sat, 04 Oct 2025 19:43:42 +0300</dateModified>
+    <dateModified>Mon, 06 Oct 2025 09:48:55 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: community'>

--- a/opml/company.opml
+++ b/opml/company.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Sat, 04 Oct 2025 19:43:42 +0300</dateModified>
+    <dateModified>Mon, 06 Oct 2025 09:48:55 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: company'>

--- a/opml/newsletter.opml
+++ b/opml/newsletter.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Sat, 04 Oct 2025 19:43:42 +0300</dateModified>
+    <dateModified>Mon, 06 Oct 2025 09:48:55 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: newsletter'>

--- a/opml/other.opml
+++ b/opml/other.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Sat, 04 Oct 2025 19:43:42 +0300</dateModified>
+    <dateModified>Mon, 06 Oct 2025 09:48:55 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: other'/>

--- a/opml/personal.opml
+++ b/opml/personal.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Sat, 04 Oct 2025 19:43:42 +0300</dateModified>
+    <dateModified>Mon, 06 Oct 2025 09:48:55 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: personal'>

--- a/opml/podcast.opml
+++ b/opml/podcast.opml
@@ -3,14 +3,21 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Sat, 04 Oct 2025 19:43:42 +0300</dateModified>
+    <dateModified>Mon, 06 Oct 2025 09:48:55 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: podcast'>
+      <outline type='rss' text='Code and the Coding Coders who Code it' xmlUrl='https://feeds.buzzsprout.com/1927628.rss'/>
+      <outline type='rss' text='Code with Jason' xmlUrl='https://feeds.buzzsprout.com/1878319.rss'/>
       <outline type='rss' text='Dead Code' xmlUrl='https://feeds.acast.com/public/shows/dead-code'/>
+      <outline type='rss' text='Friendly Show' xmlUrl='https://feeds.buzzsprout.com/2278525.rss'/>
+      <outline type='rss' text='IndieRails' xmlUrl='https://feeds.transistor.fm/indierails'/>
+      <outline type='rss' text='On Rails' xmlUrl='https://feeds.buzzsprout.com/2462975.rss'/>
       <outline type='rss' text='Remote Ruby' xmlUrl='https://feeds.buzzsprout.com/2260490.rss'/>
       <outline type='rss' text='Rooftop Ruby Podcast' xmlUrl='https://feeds.buzzsprout.com/2108545.rss'/>
       <outline type='rss' text='Ruby Rogues' xmlUrl='https://www.spreaker.com/show/6102073/episodes/feed'/>
+      <outline type='rss' text='The Bike Shed' xmlUrl='https://feeds.fireside.fm/bikeshed/rss'/>
+      <outline type='rss' text='The Ruby Gems Podcast' xmlUrl='https://feeds.buzzsprout.com/2509083.rss'/>
       <outline type='rss' text='The Ruby on Rails Podcast' xmlUrl='https://www.therubyonrailspodcast.com/rss'/>
     </outline>
   </body>

--- a/opml/social_news_aggregation.opml
+++ b/opml/social_news_aggregation.opml
@@ -3,7 +3,7 @@
   <head>
     <title>Subscriptions</title>
     <dateCreated>Sat, 30 Aug 2025 11:45:00 +1200</dateCreated>
-    <dateModified>Sat, 04 Oct 2025 19:43:42 +0300</dateModified>
+    <dateModified>Mon, 06 Oct 2025 09:48:55 -0400</dateModified>
   </head>
   <body>
     <outline text='Awesome Ruby Blogs: social_news_aggregation'>


### PR DESCRIPTION
Adds the podcasts listed below, along with RSS feeds.

All of these are active, with the latest episode released in September or October 2025.

They are also all explicitly about Ruby or Rails, with the exception of [Code with Jason](https://www.codewithjason.com/podcast), but I chose to include it anyway because many (most?) of the guests are from the Ruby community. (It used to be called "Rails with Jason".) Feel free to remove it if you feel it shouldn't be included.

* [Code and the Coding Coders who Code it](https://podcast.drbragg.dev/)
* [Code with Jason](https://www.codewithjason.com/podcast)
* [Friendly Show](https://www.friendly.show/)
* [IndieRails](https://www.indierails.com/) 
* [On Rails](https://onrails.buzzsprout.com/)
* [The Bike Shed](https://bikeshed.thoughtbot.com/)
* [The Ruby Gems Podcast](https://www.buzzsprout.com/2509083)